### PR TITLE
Fixes #9 by forcing webpack 1.9.x for now

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "react-hot-loader": "1.3.0",
     "redux-devtools": "2.1.5",
     "style-loader": "^0.12.3",
-    "webpack": "^1.9.11",
-    "webpack-dev-server": "^1.9.0"
+    "webpack": "~1.9.11",
+    "webpack-dev-server": "~1.9.0"
   }
 }


### PR DESCRIPTION
I'm not exactly sure which version of webpack was breaking, but reverting it to use `1.9.x`, rather than `1.x.x` does the trick. Mine was trying to use `1.12.x` unsuccessfully.
