### PR TITLE
Adds a 3001 port hot-relaoding server to fix #14

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "An example application using the 3REE stack!",
   "main": "server.js",
   "scripts": {
-    "start": "node server.babel.js",
+    "start": "node server.babel.js & node server.webpack.js",
     "db-setup": "node dbSetup.babel.js",
     "build": "webpack --watch",
     "build-prod": "webpack"

--- a/server.webpack.js
+++ b/server.webpack.js
@@ -6,13 +6,16 @@ new WebpackDevServer(webpack(config), {
   publicPath: config.output.publicPath,
   hot: true,
   historyApiFallback: true,
+  proxy: {
+    '*': 'http://localhost:3000'
+  },
   stats: {
     colors: true
   }
-}).listen(3000, 'localhost', function (err) {
+}).listen(3001, 'localhost', function (err) {
   if (err) {
     console.log(err);
   }
 
-  console.log('Listening at localhost:3000');
+  console.log('Dev server listening at localhost:3001');
 });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,6 +4,8 @@ var webpack = require('webpack');
 module.exports = {
   devtool: 'eval',
   entry: [
+    'webpack-dev-server/client?http://localhost:3001',
+    'webpack/hot/only-dev-server',
     './client/app'
   ],
   output: {


### PR DESCRIPTION
I'm not sure if this is ideal, running two separate server files, but I figured a proxy to :3000 would be best.

Might be better to combine the two server scripts and use NODE_ENV to determine? I debated on that.
