### PR TITLE
Use localhost as default host for rethinkdb

### DIFF
--- a/server/api/config.json
+++ b/server/api/config.json
@@ -1,5 +1,5 @@
 {
-  "host": "192.168.33.18",
+  "host": "localhost",
   "port": 28015,
   "db": "pulse"
 }


### PR DESCRIPTION
For out of the box rethinkdb configurations. Not a big deal but more generic.
