### PR TITLE
Added start:win npm script command to support Windows development env…

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,13 @@ You will need to install [RethinkDB](http://www.rethinkdb.com). You can find ins
 
 ### Running Dev Server
 
- - Run `npm start` will start Webpack dev server - for serving the client, and also start the API server
- - Go to http://localhost:3001 in two seperate tabs - see changes propagate in real time (Hot Module Replacement works too)
+On Linux/OSX: `npm start`
+
+On Windows: `npm run start:win`
+
+This will start the Webpack dev server - for serving the client, as well as the server-side API.
+
+Go to http://localhost:3001 in two separate tabs - see changes propagate in real time (Hot Module Replacement works too).
 
 ### Running Production Server
 
@@ -49,6 +54,8 @@ You will need to roll out your own deployment script for a server, but before yo
  - Set up nginx or your web server of choice to map HTTP requests for your URL to `http://localhost:3000`
  - Run `npm run start:prod` to run on your server
  - Go to your URL
+
+NOTE: Production has not been tested on Windows.
 
 ### Tech Used
 
@@ -63,7 +70,3 @@ You will need to roll out your own deployment script for a server, but before yo
 | [Webpack](https://webpack.github.io/) | Module bundling + build for client | 1.13.0 |
 | [Superagent](https://github.com/visionmedia/superagent) | Universal http requests | 1.8.0 |
 | [Stylus](http://stylus-lang.com/) | Expressive, dynamic, robust CSS | 0.54.0 |
-
-
-
-

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build:prod": "NODE_ENV=production webpack",
     "db-setup": "node dbSetup.babel.js",
     "lint": "eslint client server universal test server.js dbSetup.js",
-    "start": "NODE_ENV=development node server.babel.js & node server.webpack.js",
+    "start": "NODE_ENV=development node start-dev.js",
+    "start:win": "set NODE_ENV=development&&node start-dev.js",
     "start:prod": "NODE_ENV=production node server.babel.js",
     "test": "./node_modules/karma/bin/karma start"
   },

--- a/start-dev.js
+++ b/start-dev.js
@@ -1,0 +1,2 @@
+require('./server.babel.js');
+require('./server.webpack.js');


### PR DESCRIPTION
…ironments. Created start-dev.js entry script for less verbose package.json script commands

Per comments and suggestion in #45 and #46.

Updated README for how-to start dev server in nix vs. Windows.  
